### PR TITLE
Add OpenAI key placeholder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,6 @@ OPENROUTER_API_KEY=your-openrouter-api-key
 # CLAUDE_HAIKU=anthropic/claude-haiku-4
 # GPT_MINI=openai/gpt-4o-mini
 # LLAMA_MODEL=meta-llama/llama-3.3-70b-instruct
+
+# OpenAI API Key for Whisper transcription and embeddings
+OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cp .env.example .env
 
 # Set your keys:
 # - SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY from Supabase Dashboard
-# - OPENROUTER_API_KEY from OpenRouter
+# - OPENROUTER_API_KEY or OPENAI_API_KEY from OpenRouter/OpenAI
 # - DROPBOX_APP_KEY, DROPBOX_APP_SECRET, DROPBOX_ACCESS_TOKEN from Dropbox App Console
 ```
 
@@ -42,6 +42,7 @@ supabase functions deploy analyze
 
 # Set environment variables in Supabase
 supabase secrets set OPENROUTER_API_KEY=your-openrouter-key
+supabase secrets set OPENAI_API_KEY=your-openai-key
 supabase secrets set DROPBOX_APP_SECRET=your-dropbox-app-secret
 supabase secrets set DROPBOX_ACCESS_TOKEN=your-dropbox-access-token
 ```


### PR DESCRIPTION
## Summary
- add `OPENAI_API_KEY` placeholder to `.env.example`
- document `OPENAI_API_KEY` usage in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68547e392a04832c8fdd81b429f4eb76