### PR TITLE
Switch analysis model to GPT o3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ SUPABASE_ANON_KEY=your-anon-key
 
 # AI Services
 OPENROUTER_API_KEY=your-openrouter-key
-CLAUDE_MODEL=openai/gpt-4o
+CLAUDE_MODEL=openai/gpt-o3
 
 # Dropbox OAuth2
 DROPBOX_APP_KEY=your-app-key

--- a/supabase/functions/analyze/index.ts
+++ b/supabase/functions/analyze/index.ts
@@ -237,9 +237,9 @@ serve(async (req) => {
     const recentDreams = selectRelevantDreams(transcript, allDreams || []);
     const recurringMotifs = filterActiveMotifs(allMotifs || []);
 
-    // Step 3: Analyze with Claude Sonnet 4
+    // Step 3: Analyze with GPT o3
     try {
-      const modelName = 'openai/gpt-4o';
+      const modelName = 'openai/gpt-o3';
       const analysisPrompt = buildAnalysisPrompt(transcript, recentDreams || [], recurringMotifs || [], modelName);
       
       const analysisResponse = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {

--- a/supabase/functions/chat/index.ts
+++ b/supabase/functions/chat/index.ts
@@ -170,7 +170,7 @@ When no dreams are available, guide users toward meaningful dream recall and ana
 
     console.log('Sending request to LLM...');
 
-    // 6. Generate response using Claude
+    // 6. Generate response using GPT o3
     const chatResponse = await fetch(`${OPENROUTER_BASE_URL}/chat/completions`, {
       method: 'POST',
       headers: {
@@ -178,7 +178,7 @@ When no dreams are available, guide users toward meaningful dream recall and ana
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'openai/gpt-4o',
+        model: 'openai/gpt-o3',
         messages: [
           { role: 'system', content: systemPrompt },
           { role: 'user', content: userPrompt }

--- a/supabase/functions/dashboard-insights/index.ts
+++ b/supabase/functions/dashboard-insights/index.ts
@@ -160,7 +160,7 @@ async function generateDashboardInsights(dreams: any[]): Promise<DashboardInsigh
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
-      model: 'openai/gpt-4o',
+      model: 'openai/gpt-o3',
       messages: [
         {
           role: 'system',


### PR DESCRIPTION
## Summary
- adjust Supabase functions to use `openai/gpt-o3`
- update configuration docs with new model

## Testing
- `npm install` and `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bc978ad08832cbbca7e89529dfd39